### PR TITLE
Add room allocations & salon repli info to logement_transport.md

### DIFF
--- a/06_Invités/Logement_et_Transport/logement_transport.md
+++ b/06_Invités/Logement_et_Transport/logement_transport.md
@@ -17,7 +17,42 @@ Les plans fournis par le château précisent la capacité de chaque bâtiment :
 * **Le Logis** : 4 personnes (2 chambres doubles, 1 salle de bain).  
 * **La Poterne** : 6 personnes (3 chambres doubles réparties sur trois étages, 1 salle de bain partagée).  
 
- Ces bâtiments offrent une capacité totale de **36 couchages**. La suite nuptiale se trouve au premier étage du château et dispose de sa propre salle de bain. Les plans détaillés se trouvent dans `09_Médias/Plans`.
+ Ces bâtiments offrent une capacité totale de **36 couchages**. La suite nuptiale se trouve au premier étage du 
+ 
+ ### Détail des chambres par bâtiment
+
+**Château – répartition des 5 chambres (14 couchages)**  
+- *Suite nuptiale* (1er étage) : 48 m², 1 lit double, salle de bain privée.  
+- *Léopold* (2ᵉ étage) : 44 m², 2 lits doubles.  
+- *Alice* (2ᵉ étage) : 29 m², 2 lits doubles.  
+- *Victoire* (2ᵉ étage) : 17 m², 1 lit double.  
+- *Louis* (2ᵉ étage) : 20 m², 1 lit double.  
+Espaces communs : bibliothèque (52 m²) et grand salon (69 m²) au 1er étage.
+
+**Dépendances – 5 chambres (12 couchages)**  
+- *Charlotte* : 10 m², 1 lit double.  
+- *Thierry* : 13,5 m², 1 lit double.  
+- *Jean* : 15 m², 1 lit double.  
+- *Renaud* : 15 m², 1 lit double.  
+- *Oriane* : 18,6 m², 2 lits doubles (4 couchages).  
+Cuisine et séjour au rez‑de‑chaussée, 2 salles de bain.
+
+**Le Logis – 2 chambres (4 couchages)**  
+- *Solange* : 9,2 m², 1 lit double.  
+- *Anne* : 8 m², 1 lit double.  
+Séjour de 33 m² et salle d’eau.
+
+**La Poterne – 3 chambres (6 couchages)**  
+- *Astrid* : 28 m², 1 lit double (1er étage).  
+- *Clément* : 26 m², 1 lit double (2ᵉ étage).  
+- *Inès* : 17 m², 1 lit double (3ᵉ étage).  
+Salle de bain partagée au 2 étage.
+
+### Salons et espaces de repli (RDC du château)
+
+Le rez‑de‑chaussée du château comprend plusieurs salons et pièces : **Salle du Trône** (66 m²), **Salle du Billard** (30 m²), **Salle des souvenirs** (53 m²), **Petite salle à manger** (33 m²), **Cuisine** (41 m²) et **toilettes**.  
+Ces espaces peuvent servir de repli en cas de mauvais temps pour le cocktail ou de salle de repos pour les invités.
+château et dispose de sa propre salle de bain. Les plans détaillés se trouvent dans `09_Médias/Plans`.
 
 ## Transport
 


### PR DESCRIPTION
This PR updates `06_Invités/Logement_et_Transport/logement_transport.md` to include:

- A new section detailing the allocation of rooms for each lodging: 
  - **Château**: description of suite nuptiale, Léopold, Alice, Victoire, Louis rooms and capacities (14 couchages) plus common spaces (bibliothèque et grand salon).
  - **Dépendances**: names and sizes of double and quadruple rooms (Charlotte, Thierry, Jean, Renaud, Oriane) and living spaces.
  - **Logis**: names of the two double rooms (Solange, Anne), living area and bathroom.
  - **Poterne**: names and floors of the three double rooms (Astrid, Clément, Inès) and shared bathroom.
- A new section describing the ground-floor salons of the château (Salle du Trône, Salle du Billard, Salle des souvenirs, petite salle à manger, cuisine, toilettes) that can serve as fallback or rest spaces during the cocktail or in case of bad weather.

These additions make the lodging information more precise and actionable for planning room assignments and contingency plans.